### PR TITLE
Revamp submission sent page (appears after submitting a contact form)

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,6 +1,6 @@
 var APP_PREFIX = "troop370_";
-var DATE = "06mar2019_"; // update the date and time every time the website is updated (or the content will not update on PWAs)
-var TIME = "1132";
+var DATE = "11mar2019_"; // update the date and time every time the website is updated (or the content will not update on PWAs)
+var TIME = "1821";
 var CACHE_NAME = APP_PREFIX + DATE + TIME;
 var URLS = [
   "./index.html?utm_source=homescreen",

--- a/styles/checkmark.css
+++ b/styles/checkmark.css
@@ -1,0 +1,49 @@
+.checkmark__circle {
+  stroke-dasharray: 166;
+  stroke-dashoffset: 166;
+  stroke-width: 6;
+  stroke-miterlimit: 10;
+  stroke: var(--mdc-theme-primary_accent_text-on-background);
+  fill: none;
+  animation: stroke 0.6s cubic-bezier(0.65, 0, 0.45, 1) forwards;
+}
+
+.checkmark {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  display: block;
+  stroke-width: 2;
+  stroke: var(--mdc-theme-background);
+  stroke-miterlimit: 10;
+  margin: 10% auto;
+  box-shadow: inset 0px 0px 0px var(--mdc-theme-primary_accent_text-on-background);
+  animation: fill .4s ease-in-out .4s forwards, scale .3s ease-in-out .9s both;
+}
+
+.checkmark__check {
+  transform-origin: 50% 50%;
+  stroke-dasharray: 48;
+  stroke-dashoffset: 48;
+  animation: stroke 0.3s cubic-bezier(0.65, 0, 0.45, 1) 0.8s forwards;
+}
+
+@keyframes stroke {
+  100% {
+    stroke-dashoffset: 0;
+  }
+}
+@keyframes scale {
+  0%, 100% {
+    transform: none;
+  }
+  50% {
+    transform: scale3d(1.1, 1.1, 1);
+  }
+}
+@keyframes fill {
+  100% {
+    box-shadow: inset 0px 0px 0px 30px var(--mdc-theme-primary_accent_text-on-background);
+  }
+}
+/*original version by Hybrid8287*/

--- a/submission-received.html
+++ b/submission-received.html
@@ -1,34 +1,23 @@
 ---
 layout: default
+title: Submission Sent
+theme: light
+mobile-theme: light
 ---
 <!DOCTYPE html>
-<html lang="en">
+<html>
   <head>
-    
-    <title>Submission Sent</title>
-    
-    
-    
-    
-    
-    
-    
+    <title>{{page.title}} | {{site.title}}</title>
+    <link rel='stylesheet' href='styles/checkmark.css'>
   </head>
-  <body style="background-color: var(--banner-background-color);">
-    <div class="banner">
-      <container class="center" style="height:calc(100vh - 185px);padding-top:0;padding-bottom:0;">
+  <body>
+    <div class="banner white">
+      <container class="center">
+        <svg class="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 52"><circle class="checkmark__circle" cx="26" cy="26" r="25" fill="none"/><path class="checkmark__check" fill="none" d="M14.1 27.2l7.1 7.2 16.7-16.8"/></svg>
         <h3 class="size8">Submission Sent</h3>
-        <div class="buttonrow">
-          <a href="contact.html#contact" class="mdc-button standard-light-button mdc-button--outlined">Return</a>
-        </div>
       </div>
+    <div style="position:absolute;bottom:30px;text-align:center;width:100%;">
+      <a href="contact.html#contact" class="mdc-button mdc-button--raised standard-dark-button" style="padding:0 24px">Return</a>
     </div>
-  <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-  <script type='text/javascript' src='scripts/insert-header-footer.js'></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.8/js/materialize.js"></script>
-  <script type="text/javascript">
-  	$(".button-collapse").sideNav();
-  </script><div class="drag-target" data-sidenav="slide-out" style="left: 0px; touch-action: pan-y;"></div>
-  <div class="hiddendiv common"></div>
   </body>
 </html>


### PR DESCRIPTION
This PR will enable the new version of the submission sent page, which includes the following changes:
- removes colored background
- moves return button to the bottom of the page to make it easier for mobile users to reach the button
- makes the button filled because it is the primary action
- adds a nice animated check mark
- adds page title to app bar
- includes the site title after the page title in the browser tab ("Submission Sent | BSA Troop 370" instead of "Submission Sent")
- works with the dark theme


|Before|After-Light|After-Dark|
|---|---|---|
|![submission sent before](https://user-images.githubusercontent.com/16235094/54162414-c4599b00-442b-11e9-94ac-304c1d29cff5.png)|![submission sent light](https://user-images.githubusercontent.com/16235094/54162420-ca4f7c00-442b-11e9-87e1-22b254608248.png)|![submission sent dark](https://user-images.githubusercontent.com/16235094/54162445-de937900-442b-11e9-8d0e-52d2c92675dc.png)|

This PR resolves #50.