### PR TITLE
Add all leadership to the leaders page with pictures, names, and positons

### DIFF
--- a/_includes/profile-card.html
+++ b/_includes/profile-card.html
@@ -1,0 +1,5 @@
+<div class="profile">
+  <img src="{{ include.image }}" style="border-color:{{ include.border-color }};">
+  <p class="name">{{ include.name }}</p>
+  <p class="position">{{ include.position }}</p>
+</div>

--- a/leaders.html
+++ b/leaders.html
@@ -9,6 +9,7 @@ collapsible-header: true
 <html lang="en">
   <head>
     <title>{{page.title}} | {{site.title}}</title>
+    <link rel='stylesheet' href='styles/profile-card.css'>
   </head>
   <body>
     <div class="content-strip">
@@ -24,6 +25,9 @@ collapsible-header: true
         <p>Cheif Instructor: Eric S</p>
         <p>Cheif Librarian: Matthew B</p>
         <p>Scribe: Santi N</p>
+        <div class="profile-box">
+          {% include profile-card.html name="" position="" border-color="" image="" %}
+        </div>
         <div class="buttonrow">
           <a class="mdc-button standard-dark-button mdc-button--outlined">More Positions & Contact Information</a>
         </div>

--- a/styles/profile-card.css
+++ b/styles/profile-card.css
@@ -1,0 +1,43 @@
+.profile-box {
+  text-align: center;
+}
+.profile {
+  text-align: center;
+  display: inline-block;
+  margin: 2px 2px 4px 0;
+  padding: 6px;
+  width: 174px;
+  height: 226px;
+  vertical-align: top;
+}
+.profile img {
+  display: inline;
+  object-fit: cover;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  border: 2px solid;
+}
+.profile .name {
+  font-weight: 500;
+  font-size: 16px;
+}
+.profile .position {
+  padding: 0;
+  font-size: 14px;
+}
+@media (max-width: 600px) {
+  .profile {
+    width: 132px;
+  }
+  .profile img {
+    width: 100px;
+    height: 100px;
+  }
+  .profile .name {
+    font-size: 14px;
+  }
+  .profile .position {
+    font-size: 13px;
+  }
+}


### PR DESCRIPTION
This PR creates a more informative leadership page that can be used by troop members to learn who is on the leadership team.

Example leadership profile card:
![image](https://user-images.githubusercontent.com/16235094/54391769-43dda900-467c-11e9-8bea-85f87ba15890.png)

This resolves #49 