### PR TITLE
Add site url to sitemap

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,5 @@
 title: BSA Troop 370
+site: "https://troop370atlanta.org"
 plugins:
   - jekyll-github-metadata
   - jekyll-sitemap


### PR DESCRIPTION
Added so that the jekyll-sitemap plugin creates the sitemap.xml file with proper urls. It currently just has the relative url, which does not work for search engines.