### PR TITLE
Hide & Disable Holiday Wreaths

### DIFF
--- a/_collections/_store/wreaths.html
+++ b/_collections/_store/wreaths.html
@@ -2,6 +2,7 @@
 layout: default
 title: Holiday Wreaths
 nav_order: 2
+menu: hide
 ---
 <style media="screen">
   .topnav:not(.scroll) #main-nav > li > a {

--- a/index.html
+++ b/index.html
@@ -22,11 +22,11 @@ title: Home
     <div class="flex-item">
       <div class="main-carousel" data-flickity='{ "cellAlign": "left", "contain": true, "autoPlay": 4000, "freeScroll": true, "pageDots": false }'>
         {% include main-carousel-card.html
-            card-title="Holiday Wreaths Sale"
-            card-subtitle="Purchase by October 30"
-            card-href="/pay/wreaths.html"
+            card-title="Pine Straw Sale"
+            card-subtitle="Order by October 31"
+            card-href="/pay/pinestraw.html"
             button-text="More info &amp; Buy"
-            background-image="/src/carousel-images/spruceneedles.jpg"
+            background-image="/src/carousel-images/pineneedles_l.jpg"
         %}
         {% include main-carousel-card.html
             card-title="Update Contact Info"


### PR DESCRIPTION
This PR _removes_ the holiday wreaths carousel card on the home page and _hides_ the holiday wreaths page from navigation.
The store pages have already been _disabled_ on Ecwid.