### PR TITLE
Hide & Disable Pine Straw

### DIFF
--- a/_collections/_store/pinestraw.html
+++ b/_collections/_store/pinestraw.html
@@ -2,6 +2,7 @@
 layout: default
 title: Pine Straw
 nav_order: 1
+menu: hide
 redirect_from:
  - pinestraw.html
  - store.html

--- a/index.html
+++ b/index.html
@@ -22,13 +22,6 @@ title: Home
     <div class="flex-item">
       <div class="main-carousel" data-flickity='{ "cellAlign": "left", "contain": true, "autoPlay": 4000, "freeScroll": true, "pageDots": false }'>
         {% include main-carousel-card.html
-            card-title="Pine Straw Sale"
-            card-subtitle="Order by October 31"
-            card-href="/pay/pinestraw.html"
-            button-text="More info &amp; Buy"
-            background-image="/src/carousel-images/pineneedles_l.jpg"
-        %}
-        {% include main-carousel-card.html
             card-title="Update Contact Info"
             card-subtitle="Update information in TroopMaster to prepare for upcoming communication changes"
             card-href="contact-info-directions.html"


### PR DESCRIPTION
This PR _removes_ the pine straw carousel card on the home page and _hides_ the pine straw page from navigation.
The store pages have already been _disabled_ on Ecwid.