### PR TITLE
Remove campout and contact info banners; show contact info update instructions in navigation

### DIFF
--- a/_collections/_information/contact-info-directions.html
+++ b/_collections/_information/contact-info-directions.html
@@ -1,8 +1,7 @@
 ---
 layout: default
 title: Update Contact Information
-nav_order: 100
-menu: hide
+nav_order: 8
 redirect_from: contact-info-directions.html
 ---
 <div class="content-strip content-strip--primary content-strip--extra-padding content-strip--center">

--- a/index.html
+++ b/index.html
@@ -22,13 +22,6 @@ title: Home
     <div class="flex-item">
       <div class="main-carousel" data-flickity='{ "cellAlign": "left", "contain": true, "autoPlay": 4000, "freeScroll": true, "pageDots": false }'>
         {% include main-carousel-card.html
-            card-title="Shooting Sports Campout"
-            card-subtitle="November 16-17"
-            card-href="/members/campout-sign-up.html"
-            button-text="Sign Up"
-            background-image="/src/carousel-images/forest-with-mountains.png"
-        %}
-        {% include main-carousel-card.html
           card-title="Being A Merit Badge Counselor"
           card-subtitle="New Training Available in Adult Training section"
           card-href="/information/forms-documents.html"

--- a/index.html
+++ b/index.html
@@ -29,13 +29,6 @@ title: Home
           background-image="/src/carousel-images/blackboard.jpg"
         %}
         {% include main-carousel-card.html
-            card-title="Update Contact Info"
-            card-subtitle="Update information in TroopMaster to prepare for upcoming communication changes"
-            card-href="contact-info-directions.html"
-            button-text="Instructions"
-            background-image="/src/carousel-images/glorious-blue-mountain-range.jpg"
-        %}
-        {% include main-carousel-card.html
             card-title="High Adventure"
             card-subtitle="2020"
             card-href="camps-adventure.html"


### PR DESCRIPTION
This pull request does the following:

- Removes the campout sign up card for the November campout (resolves #117)
- Removes the 'Update Contact Info' card (resolves #118)
- Unhides the 'Update Contact Information' page from navigation; appears under 'Information' (resolves #119)