### PR TITLE
add descriptions and sign-up links for 2021 high adventure

### DIFF
--- a/_collections/_events/camps-adventure.html
+++ b/_collections/_events/camps-adventure.html
@@ -77,7 +77,7 @@ redirect_from: camps-adventure.html
 </div>
   <div class="content-strip content-strip--no-bottom-padding">
     <div class="flex-item">
-      <h3 class="mdc-typography--headline5">Sea Base Florida Scuba Live Aboard at Islamorada, Fl</h3>
+      <h3 class="mdc-typography--headline5">Sea Base Florida Scuba Live Aboard at Islamorada, FL</h3>
       <p>June 26 – July 3, 2021</p>
       <p> Sea Base has combined scuba with a live aboard experience to create one incredible adventure. You will spend your days discovering the Florida Keys National Marine Sanctuary above and below the water’s surface. With a crew size of 10 to 12 people, your home will be aboard one or two vessels depending on availability and schedule. During this adventure, you will dive 11 or more times including night dives (weather permitting). When you are not diving, there will be opportunities for fishing and cruising the Florida Keys. You must be a certified diver to participate in this program. Medical restrictions apply. Call Sea Base for more details.</p>
       <a href="https://docs.google.com/forms/d/e/1FAIpQLSe-A3m2BHajzrMh04EkjPfYZ3VsI51v1P6Bz3eZ3oOasM657w/viewform?fbzx=2349280234058825473" class="mdc-button">Sign up for Sea Base Scuba Live Aboard</a>

--- a/_collections/_events/camps-adventure.html
+++ b/_collections/_events/camps-adventure.html
@@ -59,7 +59,7 @@ redirect_from: camps-adventure.html
     <h2 class="mdc-typography--headline4">2021 Camps &amp; High Adventure</h2>
   </div>
 </div>
-<div class="content-strip">
+<div class="content-strip content-strip--no-bottom-padding">
   <div class="flex-item">
     <h3 class="mdc-typography--headline5">Okpik Cold Weather Camping Adventure</h3>
     <p>February 11 - 15, 2021</p>
@@ -67,3 +67,27 @@ redirect_from: camps-adventure.html
     <a href="https://docs.google.com/forms/d/e/1FAIpQLSfedvNg1l3u7hVuRgOtmPilrRJeHS8t-7E1_aw4V1qyMy5Bng/viewform" class="mdc-button">Sign up for Okpik</a>
   </div>
 </div>
+<div class="content-strip content-strip--no-bottom-padding">
+  <div class="flex-item">
+    <h3 class="mdc-typography--headline5">Sea Base St. Thomas Sailing Adventure, St. Thomas, U.S. Virgin Islands</h3>
+    <p>June 28 - July 4, 2021</p>
+    <p> Experience the allure of the U.S. Virgin Islands. Here, the trade winds blow, offering some of the best sailing in the world. Upon arrival, your crew will board a 40-foot plus vessel with an experienced captain. Most units attain the 50 Miler Award as they circumnavigate the crystal blue waters surrounding the island of St. John. In addition to sailing, your unit will snorkel pristine coral reefs, hike in Virgin Islands National Park, swim ashore to incredible beaches, and more!</p>
+    <a href="https://docs.google.com/forms/d/e/1FAIpQLSe-A3m2BHajzrMh04EkjPfYZ3VsI51v1P6Bz3eZ3oOasM657w/viewform?fbzx=2349280234058825473" class="mdc-button">Sign up for Sea Base</a>
+  </div>
+</div>
+  <div class="content-strip content-strip--no-bottom-padding">
+    <div class="flex-item">
+      <h3 class="mdc-typography--headline5">Sea Base Florida Scuba Live Aboard</h3>
+      <p>June 26 – July 3, 2021</p>
+      <p> Sea Base has combined scuba with a live aboard experience to create one incredible adventure. You will spend your days discovering the Florida Keys National Marine Sanctuary above and below the water’s surface. With a crew size of 10 to 12 people, your home will be aboard one or two vessels depending on availability and schedule. During this adventure, you will dive 11 or more times including night dives (weather permitting). When you are not diving, there will be opportunities for fishing and cruising the Florida Keys. You must be a certified diver to participate in this program. Medical restrictions apply. Call Sea Base for more details.</p>
+      <a href="https://docs.google.com/forms/d/e/1FAIpQLSe-A3m2BHajzrMh04EkjPfYZ3VsI51v1P6Bz3eZ3oOasM657w/viewform?fbzx=2349280234058825473" class="mdc-button">Sign up for Sea Base Scuba Live Aboard</a>
+    </div>
+  </div>
+  <div class="content-strip content-strip">
+    <div class="flex-item">
+      <h3 class="mdc-typography--headline5">2021 BSA National Jamboree at The Summit Bechtel Reserve</h3>
+      <p>July 21 - 30, 2020</p>
+      <p>Scouting’s flagship event is one-of-a-kind. It’s a gathering of tens of thousands of Scouts, leaders, and Jamboree Service Team members that showcases everything that is great about the Boy Scouts of America. Over the course of 10 summer days, once every four years, the Boy Scouts of America gathers together. Scouts and Scouters who attend will explore all kinds of adventures—stadium shows, pioneer village, Mount Jack hikes, adventure sports and more—in the heart of one of nature’s greatest playgrounds. With 10,000 acres at the Summit to explore, there’s no shortage of opportunities to build Scouting memories.</p>
+      <a href="https://jamboree.scouting.org/" class="mdc-button">Sign up for National Jamboree 2021</a>
+    </div>
+  </div>

--- a/_collections/_events/camps-adventure.html
+++ b/_collections/_events/camps-adventure.html
@@ -61,7 +61,7 @@ redirect_from: camps-adventure.html
 </div>
 <div class="content-strip content-strip--no-bottom-padding">
   <div class="flex-item">
-    <h3 class="mdc-typography--headline5">Okpik Cold Weather Camping Adventure</h3>
+    <h3 class="mdc-typography--headline5">Okpik Cold Weather Camping Adventure at Atikokan, Ontario</h3>
     <p>February 11 - 15, 2021</p>
     <p>Okpik Cold Weather Camping, Northern Tier’s winter offering, is the BSA’s premier winter camping program. At Okpik, Scouts experience a true Northwoods winter: learning how to thrive in subzero temperatures, travel across frozen wilderness lakes and construct their own sleeping structures out of snow. All trips are fully outfitted and provisioned, including almost all of the personal gear necessary to stay warm in the winter. A highly trained staff member, called an Interpreter, accompanies all crews on their trek.</p>
     <a href="https://docs.google.com/forms/d/e/1FAIpQLSfedvNg1l3u7hVuRgOtmPilrRJeHS8t-7E1_aw4V1qyMy5Bng/viewform" class="mdc-button">Sign up for Okpik</a>
@@ -69,15 +69,15 @@ redirect_from: camps-adventure.html
 </div>
 <div class="content-strip content-strip--no-bottom-padding">
   <div class="flex-item">
-    <h3 class="mdc-typography--headline5">Sea Base St. Thomas Sailing Adventure, St. Thomas, U.S. Virgin Islands</h3>
+    <h3 class="mdc-typography--headline5">Sea Base St. Thomas Sailing Adventure at St. Thomas, U.S. Virgin Islands</h3>
     <p>June 28 - July 4, 2021</p>
     <p> Experience the allure of the U.S. Virgin Islands. Here, the trade winds blow, offering some of the best sailing in the world. Upon arrival, your crew will board a 40-foot plus vessel with an experienced captain. Most units attain the 50 Miler Award as they circumnavigate the crystal blue waters surrounding the island of St. John. In addition to sailing, your unit will snorkel pristine coral reefs, hike in Virgin Islands National Park, swim ashore to incredible beaches, and more!</p>
-    <a href="https://docs.google.com/forms/d/e/1FAIpQLSe-A3m2BHajzrMh04EkjPfYZ3VsI51v1P6Bz3eZ3oOasM657w/viewform?fbzx=2349280234058825473" class="mdc-button">Sign up for Sea Base</a>
+    <a href="https://docs.google.com/forms/d/e/1FAIpQLSe-A3m2BHajzrMh04EkjPfYZ3VsI51v1P6Bz3eZ3oOasM657w/viewform?fbzx=2349280234058825473" class="mdc-button">Sign up for Sea Base St. Thomas</a>
   </div>
 </div>
   <div class="content-strip content-strip--no-bottom-padding">
     <div class="flex-item">
-      <h3 class="mdc-typography--headline5">Sea Base Florida Scuba Live Aboard</h3>
+      <h3 class="mdc-typography--headline5">Sea Base Florida Scuba Live Aboard at Islamorada, Fl</h3>
       <p>June 26 – July 3, 2021</p>
       <p> Sea Base has combined scuba with a live aboard experience to create one incredible adventure. You will spend your days discovering the Florida Keys National Marine Sanctuary above and below the water’s surface. With a crew size of 10 to 12 people, your home will be aboard one or two vessels depending on availability and schedule. During this adventure, you will dive 11 or more times including night dives (weather permitting). When you are not diving, there will be opportunities for fishing and cruising the Florida Keys. You must be a certified diver to participate in this program. Medical restrictions apply. Call Sea Base for more details.</p>
       <a href="https://docs.google.com/forms/d/e/1FAIpQLSe-A3m2BHajzrMh04EkjPfYZ3VsI51v1P6Bz3eZ3oOasM657w/viewform?fbzx=2349280234058825473" class="mdc-button">Sign up for Sea Base Scuba Live Aboard</a>
@@ -85,7 +85,7 @@ redirect_from: camps-adventure.html
   </div>
   <div class="content-strip content-strip">
     <div class="flex-item">
-      <h3 class="mdc-typography--headline5">2021 BSA National Jamboree at The Summit Bechtel Reserve</h3>
+      <h3 class="mdc-typography--headline5">2021 BSA National Jamboree at Summit Bechtel Reserve, WV</h3>
       <p>July 21 - 30, 2020</p>
       <p>Scouting’s flagship event is one-of-a-kind. It’s a gathering of tens of thousands of Scouts, leaders, and Jamboree Service Team members that showcases everything that is great about the Boy Scouts of America. Over the course of 10 summer days, once every four years, the Boy Scouts of America gathers together. Scouts and Scouters who attend will explore all kinds of adventures—stadium shows, pioneer village, Mount Jack hikes, adventure sports and more—in the heart of one of nature’s greatest playgrounds. With 10,000 acres at the Summit to explore, there’s no shortage of opportunities to build Scouting memories.</p>
       <a href="https://jamboree.scouting.org/" class="mdc-button">Sign up for National Jamboree 2021</a>

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@ title: Home
         %}
         {% include main-carousel-card.html
             card-title="High Adventure"
-            card-subtitle="2020"
+            card-subtitle="2021"
             card-href="camps-adventure.html"
             button-text="View list"
             background-image="/src/carousel-images/scout shadow on top of mountain with sunset.jpg"


### PR DESCRIPTION
This PR does the following:
- update high adventure carousel card to say 2021 instead of 2020
- add Sea Base St. Thomas description and link  on camps-adventure.html
- add Sea Base Live Aboard SCUBA description and link  on camps-adventure.html
- add National Jamboree 2021 description and link  on camps-adventure.html